### PR TITLE
Fix base movement to avoid over-shooting and correct turning animation

### DIFF
--- a/app/src/main/java/com/danosoftware/galaxyforce/controllers/common/ControllerImpl.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/controllers/common/ControllerImpl.java
@@ -47,7 +47,7 @@ public class ControllerImpl implements Controller {
                 // only process touch controller if no other controllers have
                 // already processed this touch point.
                 if (!processed) {
-                    processed = aTouchController.processTouchEvent(event, touchPoint, pointerID, deltaTime);
+                    processed = aTouchController.processTouchEvent(event, touchPoint, pointerID);
                 }
             }
 

--- a/app/src/main/java/com/danosoftware/galaxyforce/controllers/models/base_touch/BaseDragModel.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/controllers/models/base_touch/BaseDragModel.java
@@ -4,28 +4,12 @@ import com.danosoftware.galaxyforce.sprites.game.bases.IBasePrimary;
 
 public class BaseDragModel implements TouchBaseControllerModel {
 
-    // how far new touch point must be away from current touch point to be
-    // updated
-    private static final float TOUCH_MOVE_RADIUS = 1;
-
-    private static final double HALF_PI = (float) Math.PI / 2f;
-
-    /*
-     * large movement increased as base movement can be very jittery when the
-     * game is running slowly as base appears to be overshoot target so next
-     * move goes back in other opposite direction as so on. the slower the game
-     * is, the more the base will move and so the greater chance of overshooting
-     * we have.
-     *
-     * game optimised to run at 1/60 fps so increase BASE_MOVE_RADIUS_LARGE by
-     * ratio of actual speed to ideal speed.
-     */
-    private static final float BASE_MOVE_RADIUS_LARGE = 20;
-    private static final float BASE_MOVE_RADIUS_SMALL = 5;
-    private static final float BASE_MOVE_RADIUS_DELTA = BASE_MOVE_RADIUS_LARGE - BASE_MOVE_RADIUS_SMALL;
+    // minimum distance from current touch point for it to be updated
+    private static final float TOUCH_MOVE_RADIUS = 1f;
 
     // offset from touch point to base position
-    private static final int BASE_Y_OFFSET = -96;
+    // ensures base is positioned above finger touch position
+    private static final int BASE_Y_OFFSET = 96;
 
     // stores the position of the touch point (target position for base)
     private float targetX;
@@ -40,98 +24,29 @@ public class BaseDragModel implements TouchBaseControllerModel {
         this.targetY = base.y() + BASE_Y_OFFSET;
     }
 
-    // when finger released, reset weightings so base no longer moves
+    // when finger released, reset target position to current position
     @Override
     public void releaseTouchPoint() {
-        // no action - should we tell base?
+        base.moveTarget(base.x(), base.y());
     }
 
     // update finger position when touched down or dragged
     @Override
-    public void updateTouchPoint(float touchX, float touchY, float deltaTime) {
+    public void updateTouchPoint(float touchX, float touchY) {
 
-        /*
-        to avoid base jitter - check how far new touch point is away from
-        current touch point.
-        if distance is small then don't change current point.
-         */
         float touchDistance = (float) Math.sqrt(
                 Math.pow(touchX - targetX, 2) + Math.pow(touchY - targetY, 2));
+
+        /*
+        if distance from current target touch point to new touch point
+        is small then don't change current target.
+         */
         if (touchDistance > TOUCH_MOVE_RADIUS) {
-            // update target position based on new touch point
+            // update target position based on new touch point.
+            // base will use this to calculate it's movements.
             this.targetX = touchX;
             this.targetY = touchY;
+            base.moveTarget((int) targetX, (int) targetY + BASE_Y_OFFSET);
         }
-
-        // ensures weighting is recalculated to avoid jitter
-        updateWeighting(
-                targetX - base.x(),
-                targetY - (base.y() + BASE_Y_OFFSET),
-                deltaTime);
-    }
-
-    private void updateWeighting(float deltaX, float deltaY, float deltaTime) {
-
-        /*
-        to avoid jitter when moving - check how far base is away from current
-        touch point.
-         */
-        float baseDistance = (float) Math.sqrt(
-                (deltaX * deltaX) + (deltaY * deltaY));
-
-        /*
-         if distance large then calculate weighting purely on angle between
-         base and current touch point
-          */
-        if (baseDistance > BASE_MOVE_RADIUS_LARGE) {
-            /*
-             calculate angle from circle centre to touch point
-             atan2 doesn't have limitations of atan but is PI/2 greater than
-             expected so manually correct this.
-              */
-            float theta = (float) (HALF_PI - Math.atan2(deltaY, deltaX));
-
-            /*
-            calculate weighting (used to calculate how far to move base's x
-            and y). Ranges from 0 to 1.
-             */
-            base.moveBase(
-                    (float) Math.sin(theta),
-                    (float) Math.cos(theta),
-                    deltaTime);
-        }
-
-        /*
-         if distance small then calculate weighting based on angle but
-         multiply by a calculated weight. Much smoother movement for small
-         moves than previous calculation.
-          */
-        else if (baseDistance > BASE_MOVE_RADIUS_SMALL) {
-            /*
-             calculate angle from circle centre to touch point
-             atan2 doesn't have limitations of atan but is PI/2 greater than
-             expected so manually correct this.
-              */
-            float theta = (float) (HALF_PI - Math.atan2(deltaY, deltaX));
-
-            /*
-             calculate weighting using distance and threshold.
-             result ranges from 0-1.
-              */
-            float distanceWeight = (baseDistance - BASE_MOVE_RADIUS_SMALL)
-                    / (BASE_MOVE_RADIUS_DELTA);
-            base.moveBase(
-                    (float) (distanceWeight * Math.sin(theta)),
-                    (float) (distanceWeight * Math.cos(theta)),
-                    deltaTime);
-        }
-        // if tiny movements (maybe involuntary) then do not move
-//        else
-//        {
-//            this.weightingX = 0;
-//            this.weightingY = 0;
-//        }
-
-//        recalculateWeighting = false;
     }
 }

--- a/app/src/main/java/com/danosoftware/galaxyforce/controllers/models/base_touch/TouchBaseControllerModel.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/controllers/models/base_touch/TouchBaseControllerModel.java
@@ -15,5 +15,5 @@ public interface TouchBaseControllerModel {
      * @param touchX x co-ordinate of touch point
      * @param touchY y co-ordinate of touch point
      */
-    void updateTouchPoint(float touchX, float touchY, float deltaTime);
+    void updateTouchPoint(float touchX, float touchY);
 }

--- a/app/src/main/java/com/danosoftware/galaxyforce/controllers/touch/DetectButtonTouch.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/controllers/touch/DetectButtonTouch.java
@@ -26,7 +26,7 @@ public class DetectButtonTouch implements TouchController {
      * dragged away from button.
      */
     @Override
-    public boolean processTouchEvent(TouchEvent event, Vector2 touchPoint, int pointerID, float deltaTime) {
+    public boolean processTouchEvent(TouchEvent event, Vector2 touchPoint, int pointerID) {
         boolean processed = false;
 
         boolean buttonBounds = OverlapTester.pointInRectangle(button.getBounds(), touchPoint);

--- a/app/src/main/java/com/danosoftware/galaxyforce/controllers/touch/SwipeTouch.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/controllers/touch/SwipeTouch.java
@@ -25,7 +25,7 @@ public class SwipeTouch implements TouchController {
      * location of finger in each case.
      */
     @Override
-    public boolean processTouchEvent(TouchEvent event, Vector2 touchPoint, int pointerID, float deltaTime) {
+    public boolean processTouchEvent(TouchEvent event, Vector2 touchPoint, int pointerID) {
 
         // check finger pressed - no need to check bounds as anywhere on screen
         // is valid

--- a/app/src/main/java/com/danosoftware/galaxyforce/controllers/touch/TouchController.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/controllers/touch/TouchController.java
@@ -14,8 +14,7 @@ public interface TouchController {
      * @param event      - the touch event (e.g.TOUCH DOWN)
      * @param touchPoint - vector representing the touch point
      * @param pointerID  - pointer ID of the current touch event
-     * @param deltaTime  - time since last update
      * @return returns true if touch point was processed by this controller
      */
-    boolean processTouchEvent(TouchEvent event, Vector2 touchPoint, int pointerID, float deltaTime);
+    boolean processTouchEvent(TouchEvent event, Vector2 touchPoint, int pointerID);
 }

--- a/app/src/main/java/com/danosoftware/galaxyforce/controllers/touch_base/ControllerDrag.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/controllers/touch_base/ControllerDrag.java
@@ -1,5 +1,7 @@
 package com.danosoftware.galaxyforce.controllers.touch_base;
 
+import android.util.Log;
+
 import com.danosoftware.galaxyforce.controllers.models.base_touch.TouchBaseControllerModel;
 import com.danosoftware.galaxyforce.interfaces.Input.TouchEvent;
 import com.danosoftware.galaxyforce.view.Vector2;
@@ -18,19 +20,19 @@ public class ControllerDrag implements BaseTouchController {
     }
 
     @Override
-    public boolean processTouchEvent(TouchEvent event, Vector2 touchPoint, int pointerID, float deltaTime) {
+    public boolean processTouchEvent(TouchEvent event, Vector2 touchPoint, int pointerID) {
         boolean processed = false;
 
         // on touch down: set drag pointer, update touch point
         if (event.type == TouchEvent.TOUCH_DOWN && dragPointer == -1) {
             dragPointer = pointerID;
-            model.updateTouchPoint(touchPoint.x, touchPoint.y, deltaTime);
+            model.updateTouchPoint(touchPoint.x, touchPoint.y);
             processed = true;
         }
 
         // on drag: update touch point
         if (event.type == TouchEvent.TOUCH_DRAGGED && pointerID == dragPointer) {
-            model.updateTouchPoint(touchPoint.x, touchPoint.y, deltaTime);
+            model.updateTouchPoint(touchPoint.x, touchPoint.y);
             processed = true;
         }
 
@@ -41,6 +43,7 @@ public class ControllerDrag implements BaseTouchController {
             processed = true;
         }
 
+        Log.i("PROCESS", Integer.toString(event.type));
         return processed;
     }
 }

--- a/app/src/main/java/com/danosoftware/galaxyforce/controllers/touch_base/ControllerDrag.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/controllers/touch_base/ControllerDrag.java
@@ -1,7 +1,5 @@
 package com.danosoftware.galaxyforce.controllers.touch_base;
 
-import android.util.Log;
-
 import com.danosoftware.galaxyforce.controllers.models.base_touch.TouchBaseControllerModel;
 import com.danosoftware.galaxyforce.interfaces.Input.TouchEvent;
 import com.danosoftware.galaxyforce.view.Vector2;
@@ -43,7 +41,6 @@ public class ControllerDrag implements BaseTouchController {
             processed = true;
         }
 
-        Log.i("PROCESS", Integer.toString(event.type));
         return processed;
     }
 }

--- a/app/src/main/java/com/danosoftware/galaxyforce/game/handlers/GameHandler.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/game/handlers/GameHandler.java
@@ -18,12 +18,6 @@ public interface GameHandler extends PlayModel {
     IBasePrimary getBase();
 
     /**
-     * Called by the base when it is in position and ready to start.
-     * Allows model to start/continue the wave with the new base.
-     */
-    void baseReady();
-
-    /**
      * Pause the current game model.
      */
     void pause();

--- a/app/src/main/java/com/danosoftware/galaxyforce/game/handlers/GameHandlerFrameRateDecorator.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/game/handlers/GameHandlerFrameRateDecorator.java
@@ -12,6 +12,7 @@ import com.danosoftware.galaxyforce.sprites.refactor.ISprite;
 import com.danosoftware.galaxyforce.text.Text;
 import com.danosoftware.galaxyforce.view.FPSCounter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -44,7 +45,8 @@ public class GameHandlerFrameRateDecorator implements GameHandler {
 
     @Override
     public List<Text> getText() {
-        List<Text> text = gameHandler.getText();
+        List<Text> text = new ArrayList<>();
+        text.addAll(gameHandler.getText());
         text.add(tempFps);
 
         return text;

--- a/app/src/main/java/com/danosoftware/galaxyforce/game/handlers/GameHandlerFrameRateDecorator.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/game/handlers/GameHandlerFrameRateDecorator.java
@@ -64,11 +64,6 @@ public class GameHandlerFrameRateDecorator implements GameHandler {
     }
 
     @Override
-    public void baseReady() {
-        gameHandler.baseReady();
-    }
-
-    @Override
     public void initialise() {
         gameHandler.initialise();
     }

--- a/app/src/main/java/com/danosoftware/galaxyforce/game/handlers/GamePlayHandler.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/game/handlers/GamePlayHandler.java
@@ -65,7 +65,7 @@ public class GamePlayHandler implements GameHandler {
      */
 
     private enum ModelState {
-        GET_READY, NEW_BASE, PLAYING
+        GET_READY, PLAYING
     }
 
     private static final String TAG = GamePlayHandler.class.getSimpleName();
@@ -262,13 +262,6 @@ public class GamePlayHandler implements GameHandler {
 
                 break;
 
-            case NEW_BASE:
-
-                // Move new base to starting position.
-                primaryBase.animate(deltaTime);
-
-                break;
-
             default:
                 String errorMsg = "Illegal Model State : " + modelState.name();
                 Log.e(TAG, errorMsg);
@@ -286,12 +279,6 @@ public class GamePlayHandler implements GameHandler {
     @Override
     public IBasePrimary getBase() {
         return primaryBase;
-    }
-
-    // called by the base when it is in position and ready to start
-    @Override
-    public void baseReady() {
-        modelState = ModelState.PLAYING;
     }
 
     @Override
@@ -615,8 +602,7 @@ public class GamePlayHandler implements GameHandler {
         // update displayed number of lives
         assets.setLives(lives);
 
-        // change model state to handle movement of base to starting position
-        modelState = ModelState.NEW_BASE;
+        modelState = ModelState.PLAYING;
     }
 
     /**

--- a/app/src/main/java/com/danosoftware/galaxyforce/model/screens/GameModelImpl.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/model/screens/GameModelImpl.java
@@ -7,6 +7,7 @@ import com.danosoftware.galaxyforce.constants.GameConstants;
 import com.danosoftware.galaxyforce.controllers.common.Controller;
 import com.danosoftware.galaxyforce.enumerations.ModelState;
 import com.danosoftware.galaxyforce.game.handlers.GameHandler;
+import com.danosoftware.galaxyforce.game.handlers.GameHandlerFrameRateDecorator;
 import com.danosoftware.galaxyforce.game.handlers.GameOverHandler;
 import com.danosoftware.galaxyforce.game.handlers.GamePlayHandler;
 import com.danosoftware.galaxyforce.game.handlers.PausedHandler;
@@ -85,8 +86,8 @@ public class GameModelImpl implements GameModel {
         stars = Star.setupStars(GameConstants.GAME_WIDTH, GameConstants.GAME_HEIGHT, GameSpriteIdentifier.STAR_ANIMATIONS);
 
         // initial handler - goes straight into game
-        this.modelHandler = new GamePlayHandler(this, controller, stars, wave, billingService);
-
+        GameHandler gameHandler = new GamePlayHandler(this, controller, stars, wave, billingService);
+        this.modelHandler = new GameHandlerFrameRateDecorator(gameHandler);
         this.modelState = ModelState.RUNNING;
     }
 
@@ -186,7 +187,8 @@ public class GameModelImpl implements GameModel {
                     this.lastWave = 1;
                 }
 
-                modelHandler = new GamePlayHandler(this, controller, stars, lastWave, billingService);
+                GameHandler gameHandler = new GamePlayHandler(this, controller, stars, lastWave, billingService);
+                modelHandler = new GameHandlerFrameRateDecorator(gameHandler);
                 modelHandler.initialise();
 
                 // set state back to running so doesn't create new handlers every

--- a/app/src/main/java/com/danosoftware/galaxyforce/sprites/game/bases/IBasePrimary.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/sprites/game/bases/IBasePrimary.java
@@ -6,7 +6,11 @@ import java.util.List;
 
 public interface IBasePrimary extends IBase {
 
-    void moveBase(float weightingX, float weightingY, float deltaTime);
+    /**
+     * Set the wanted target position of the base.
+     * Base will gradually move to this position.
+     */
+    void moveTarget(int targetX, int targetY);
 
     void helperExploding(HelperSide side);
 

--- a/app/src/main/java/com/danosoftware/galaxyforce/sprites/game/bases/enums/BaseState.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/sprites/game/bases/enums/BaseState.java
@@ -5,7 +5,6 @@ package com.danosoftware.galaxyforce.sprites.game.bases.enums;
  */
 public enum BaseState {
 
-    MOVING_TO_START_POSITION,
     ACTIVE,
     EXPLODING,
     DESTROYED

--- a/app/src/main/java/com/danosoftware/galaxyforce/sprites/refactor/AlienManager.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/sprites/refactor/AlienManager.java
@@ -102,8 +102,6 @@ public class AlienManager implements IAlienManager {
 
         // handles complex sub-wave scenarios
         updateSubWaveState();
-
-        Log.i("AlienManager", "SubWave State: " + subWaveState + ". Total Aliens: " + aliens.size() + ". Active Aliens: " + activeAliens.size());
     }
 
     @Override

--- a/app/src/main/java/com/danosoftware/galaxyforce/sprites/refactor/MoveBaseHelper.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/sprites/refactor/MoveBaseHelper.java
@@ -1,7 +1,5 @@
 package com.danosoftware.galaxyforce.sprites.refactor;
 
-import android.util.Log;
-
 import com.danosoftware.galaxyforce.sprites.game.bases.IBase;
 
 import static com.danosoftware.galaxyforce.constants.GameConstants.GAME_HEIGHT;
@@ -189,7 +187,6 @@ public class MoveBaseHelper {
               */
             float distanceWeight = (baseDistance - BASE_MOVE_RADIUS_SMALL)
                     / (BASE_MOVE_RADIUS_DELTA);
-            Log.i("TEST", "- baseDistance");
             weightingX = (float) (distanceWeight * Math.sin(theta));
             weightingY = (float) (distanceWeight * Math.cos(theta));
         }

--- a/app/src/main/java/com/danosoftware/galaxyforce/sprites/refactor/MoveBaseHelper.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/sprites/refactor/MoveBaseHelper.java
@@ -98,6 +98,20 @@ public class MoveBaseHelper {
         int x = base.x() + (int) (maxDistanceMoved * weightingX);
         int y = base.y() + (int) (maxDistanceMoved * weightingY);
 
+        // don't allow weightings to over-shoot targets
+        if (weightingX > 0 && x > targetX) {
+            x = targetX;
+        }
+        if (weightingX < 0 && x < targetX) {
+            x = targetX;
+        }
+        if (weightingY > 0 && y > targetY) {
+            y = targetY;
+        }
+        if (weightingY < 0 && y < targetY) {
+            y = targetY;
+        }
+
         // don't allow base to go off screen top
         if ((y + base.halfHeight()) > GAME_HEIGHT) {
             y = (GAME_HEIGHT - base.halfHeight());

--- a/app/src/main/java/com/danosoftware/galaxyforce/sprites/refactor/MoveBaseHelper.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/sprites/refactor/MoveBaseHelper.java
@@ -1,7 +1,10 @@
 package com.danosoftware.galaxyforce.sprites.refactor;
 
+import android.util.Log;
+
 import com.danosoftware.galaxyforce.sprites.game.bases.IBase;
 
+import static com.danosoftware.galaxyforce.constants.GameConstants.GAME_HEIGHT;
 import static com.danosoftware.galaxyforce.sprites.properties.GameSpriteIdentifier.BASE;
 import static com.danosoftware.galaxyforce.sprites.properties.GameSpriteIdentifier.BASE_LEFT;
 import static com.danosoftware.galaxyforce.sprites.properties.GameSpriteIdentifier.BASE_RIGHT;
@@ -17,17 +20,34 @@ import static com.danosoftware.galaxyforce.sprites.properties.GameSpriteIdentifi
  */
 public class MoveBaseHelper {
 
+    private static final double HALF_PI = (float) Math.PI / 2f;
+
+    /*
+     * large movement increased as base movement can be very jittery when the
+     * game is running slowly as base appears to be overshoot target so next
+     * move goes back in other opposite direction as so on. the slower the game
+     * is, the more the base will move and so the greater chance of overshooting
+     * we have.
+     *
+     * game optimised to run at 1/60 fps so increase BASE_MOVE_RADIUS_LARGE by
+     * ratio of actual speed to ideal speed.
+     */
+    private static final float BASE_MOVE_RADIUS_LARGE = 20;
+    private static final float BASE_MOVE_RADIUS_SMALL = 5;
+    private static final float BASE_MOVE_RADIUS_DELTA = BASE_MOVE_RADIUS_LARGE - BASE_MOVE_RADIUS_SMALL;
+
+
     // distance base can move each second in pixels
     private static final int BASE_MOVE_PIXELS = 10 * 60;
 
     // weighting that must be exceeded to trigger base left or right turn
-    private static float WEIGHTING_TURN = 0.5f;
+    private static final float WEIGHTING_TURN = 0.5f;
 
     // increased for tilt controller as weighting never goes close to zero in tilt mode
-    private static float WEIGHTING_STEADY = 0.1f;
+    private static final float WEIGHTING_STEADY = 0.1f;
 
     // number of seconds for base to be steady for before resetting left or right turn
-    private static float STEADY_DELAY = 0.1f;
+    private static final float STEADY_DELAY = 0.1f;
 
     // base being animated
     private final IBase base;
@@ -38,26 +58,38 @@ public class MoveBaseHelper {
     // is base currently turning left or right?
     private boolean baseTurning;
 
-    // width/height of actual usable screen */
-    private final int width, height;
+    // target position of where we want base to move to
+    private int targetX, targetY;
+
+    // current weighting of base movement
+    private float weightingX, weightingY;
 
 
     public MoveBaseHelper(
-            final IBase base,
-            final int width,
-            final int height) {
+            final IBase base) {
 
         this.base = base;
-        this.width = width;
-        this.height = height;
         this.baseTurnSteadyTime = 0f;
         this.baseTurning = false;
+        this.weightingX = 0f;
+        this.weightingY = 0f;
+        this.targetX = base.x();
+        this.targetY = base.y();
+    }
+
+    public void updateTarget(int targetX, int targetY) {
+        this.targetX = targetX;
+        this.targetY = targetY;
     }
 
     /**
      * Moves base by the supplied weighting
      */
-    public void moveBase(float weightingX, float weightingY, float deltaTime) {
+    public void moveBase(float deltaTime) {
+
+        updateWeighting(
+                targetX - base.x(),
+                targetY - base.y());
 
         /*
          * can cause jittery movement if game is running very slowly as base
@@ -68,24 +100,9 @@ public class MoveBaseHelper {
         int x = base.x() + (int) (maxDistanceMoved * weightingX);
         int y = base.y() + (int) (maxDistanceMoved * weightingY);
 
-        // don't allow base to go off screen left
-        if (x - base.halfWidth() < 0) {
-            x = base.halfWidth();
-        }
-
-        // don't allow base to go off screen right
-        if ((x + base.halfWidth()) > width) {
-            x = (width - base.halfWidth());
-        }
-
-        // don't allow base to go off screen bottom
-        if ((y - base.halfHeight()) < 0) {
-            y = base.halfHeight();
-        }
-
         // don't allow base to go off screen top
-        if ((y + base.halfHeight()) > height) {
-            y = (height - base.halfHeight());
+        if ((y + base.halfHeight()) > GAME_HEIGHT) {
+            y = (GAME_HEIGHT - base.halfHeight());
         }
 
         // move base to new position
@@ -122,6 +139,64 @@ public class MoveBaseHelper {
                 baseTurnSteadyTime = 0f;
                 baseTurning = false;
             }
+        }
+    }
+
+    private void updateWeighting(float deltaX, float deltaY) {
+
+        /*
+        to avoid jitter when moving - check how far base is away from target.
+         */
+        float baseDistance = (float) Math.sqrt(
+                (deltaX * deltaX) + (deltaY * deltaY));
+
+        /*
+         if distance large then calculate weighting purely on angle between
+         base and current touch point
+          */
+        if (baseDistance > BASE_MOVE_RADIUS_LARGE) {
+            /*
+             calculate angle from circle centre to touch point
+             atan2 doesn't have limitations of atan but is PI/2 greater than
+             expected so manually correct this.
+              */
+            float theta = (float) (HALF_PI - Math.atan2(deltaY, deltaX));
+
+            /*
+            calculate weighting (used to calculate how far to move base's x
+            and y). Ranges from 0 to 1.
+             */
+            weightingX = (float) Math.sin(theta);
+            weightingY = (float) Math.cos(theta);
+        }
+
+        /*
+         if distance small then calculate weighting based on angle but
+         multiply by a calculated weight. Much smoother movement for small
+         moves than previous calculation.
+          */
+        else if (baseDistance > BASE_MOVE_RADIUS_SMALL) {
+            /*
+             calculate angle from circle centre to touch point
+             atan2 doesn't have limitations of atan but is PI/2 greater than
+             expected so manually correct this.
+              */
+            float theta = (float) (HALF_PI - Math.atan2(deltaY, deltaX));
+
+            /*
+             calculate weighting using distance and threshold.
+             result ranges from 0-1.
+              */
+            float distanceWeight = (baseDistance - BASE_MOVE_RADIUS_SMALL)
+                    / (BASE_MOVE_RADIUS_DELTA);
+            Log.i("TEST", "- baseDistance");
+            weightingX = (float) (distanceWeight * Math.sin(theta));
+            weightingY = (float) (distanceWeight * Math.cos(theta));
+        }
+        // if base is very close to touch point then reset weightings
+        else {
+            weightingX = 0f;
+            weightingY = 0f;
         }
     }
 }

--- a/app/src/test/java/com/danosoftware/galaxyforce/sprites/refactor/PrimaryBaseTest.java
+++ b/app/src/test/java/com/danosoftware/galaxyforce/sprites/refactor/PrimaryBaseTest.java
@@ -104,45 +104,44 @@ public class PrimaryBaseTest {
 
     @Test()
     public void shouldMoveBaseX() {
+        // move x left to right
         primaryBase.move(0, 0);
-        primaryBase.moveBase(1, 0, 0.5f);
+        primaryBase.moveTarget(300, 0);
+        primaryBase.animate(10f);
+        assertThat(primaryBase.x(), is(300));
+        assertThat(primaryBase.y(), is(0));
+
+        // move x right to left
+        primaryBase.move(GAME_WIDTH, 0);
+        primaryBase.moveTarget(300, 0);
+        primaryBase.animate(10f);
         assertThat(primaryBase.x(), is(300));
         assertThat(primaryBase.y(), is(0));
     }
 
     @Test()
     public void shouldMoveBaseY() {
+        // move y bottom to top
         primaryBase.move(0, 0);
-        primaryBase.moveBase(0, 1, 0.5f);
+        primaryBase.moveTarget(0, 300);
+        primaryBase.animate(10f);
         assertThat(primaryBase.x(), is(0));
         assertThat(primaryBase.y(), is(300));
-    }
 
-    // this test will move test sprite to max position
-    // since mocked width and height are 0.
-    // normal sprite will take its size into account.
-    @Test()
-    public void shouldNotMoveBeyondMaximumPosition() {
-        primaryBase.moveBase(1, 1, 10f);
-        assertThat(primaryBase.x(), is(GAME_WIDTH));
-        assertThat(primaryBase.y(), is(GAME_HEIGHT));
-    }
-
-    // this test will move test sprite to origin position
-    // since mocked width and height are 0.
-    // normal sprite will take its size into account.
-    @Test()
-    public void shouldNotMoveBeyondOrigin() {
-        primaryBase.moveBase(-1, -1, 10f);
+        // move y top to bottom
+        primaryBase.move(0, GAME_HEIGHT);
+        primaryBase.moveTarget(0, 300);
+        primaryBase.animate(10f);
         assertThat(primaryBase.x(), is(0));
-        assertThat(primaryBase.y(), is(0));
+        assertThat(primaryBase.y(), is(300));
     }
 
     @Test()
     public void shouldNotMoveAfterBeingDestroyed() {
         primaryBase.move(0, 0);
         primaryBase.destroy();
-        primaryBase.moveBase(1, 1, 5f);
+        primaryBase.moveTarget(100, 100);
+        primaryBase.animate(10f);
 
         // confirm base hasn't moved
         assertThat(primaryBase.x(), is(0));


### PR DESCRIPTION
Refactoring base controller so that weighting is calculated during the animation cycle. Previous implementation only updated base movement weightings following fingers movements, which caused inaccurate base movements when finger is stationary and so weighting remains unchanged.