### PR TITLE
Fix bug where version number appears to early on splash-screen

### DIFF
--- a/app/src/main/java/com/danosoftware/galaxyforce/models/screens/SplashModelImpl.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/models/screens/SplashModelImpl.java
@@ -150,7 +150,11 @@ public class SplashModelImpl implements Model, TouchScreenModel, BillingObserver
         // increment splash screen time count by deltaTime
         splashScreenTime += deltaTime;
 
-        if (reBuildText || splashScreenTime > DELAY_IN_SECONDS_BEFORE_TEXT_DISPLAYED) {
+        // display version state if...
+        // set time has elapsed or...
+        // a billing state update is received and set time has elapsed
+        if ((splashScreenTime > DELAY_IN_SECONDS_BEFORE_TEXT_DISPLAYED) ||
+                (reBuildText && splashScreenTime > DELAY_IN_SECONDS_BEFORE_TEXT_DISPLAYED)) {
             buildTextMessages();
             reBuildText = false;
         }


### PR DESCRIPTION
Fix bug where version number appears to early on splash-screen if game paused before it appears. This fixes #115