### PR TITLE
Fix get ready for next wave message bug.

### DIFF
--- a/app/src/main/java/com/danosoftware/galaxyforce/models/assets/GamePlayAssetsManager.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/models/assets/GamePlayAssetsManager.java
@@ -118,4 +118,9 @@ public class GamePlayAssetsManager implements IGamePlayAssetsManager {
     public List<Life> getLives() {
         return lives;
     }
+
+    @Override
+    public boolean alienMissilesDestroyed() {
+        return aliensMissiles.isEmpty();
+    }
 }

--- a/app/src/main/java/com/danosoftware/galaxyforce/models/assets/IGamePlayAssetsManager.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/models/assets/IGamePlayAssetsManager.java
@@ -37,4 +37,6 @@ public interface IGamePlayAssetsManager {
     List<Flag> getFlags();
 
     List<Life> getLives();
+
+    boolean alienMissilesDestroyed();
 }

--- a/app/src/main/java/com/danosoftware/galaxyforce/models/screens/game/GamePlayModelImpl.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/models/screens/game/GamePlayModelImpl.java
@@ -384,7 +384,7 @@ public class GamePlayModelImpl implements Model, GameModel {
      * level.
      */
     private void updatePlayingState() {
-        if (alienManager.isWaveComplete()) {
+        if (isWaveComplete()) {
 
             // check user is allowed to play next wave
             if (wave >= GameConstants.MAX_FREE_WAVE
@@ -420,7 +420,7 @@ public class GamePlayModelImpl implements Model, GameModel {
                 return;
             }
             // advance to next level
-            else {
+            else if (primaryBase.isActive()) {
                 Log.i(TAG, "Wave: New Wave");
                 wave++;
                 int maxLevelUnlocked = savedGame.getGameLevel();
@@ -441,15 +441,17 @@ public class GamePlayModelImpl implements Model, GameModel {
              * model state.
              */
             setupNewBase();
-        } else if (alienManager.isWaveComplete()) {
+        } else if (isWaveComplete() && primaryBase.isActive()) {
             /*
              * if base not destroyed and wave finished then start next level.
-             * special case: if the base and last alien was destroyed at the
-             * same time, then the new base state will handle the setting up of
-             * the next level after it leaves the new base state.
              */
             setupLevel();
         }
+    }
+
+    private boolean isWaveComplete() {
+        return alienManager.isWaveComplete() &&
+                assets.alienMissilesDestroyed();
     }
 
     /**

--- a/app/src/main/java/com/danosoftware/galaxyforce/sprites/game/bases/BaseHelper.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/sprites/game/bases/BaseHelper.java
@@ -91,7 +91,7 @@ public class BaseHelper extends AbstractCollidingSprite implements IBaseHelper {
      * - Creates new helper
      * - Registers helper with primary base
      */
-    public static void createHelperBase(
+    static void createHelperBase(
             final IBasePrimary primaryBase,
             final GameModel model,
             final SoundPlayerService sounds,
@@ -240,6 +240,11 @@ public class BaseHelper extends AbstractCollidingSprite implements IBaseHelper {
     @Override
     public boolean isDestroyed() {
         return state == DESTROYED;
+    }
+
+    @Override
+    public boolean isActive() {
+        return state == ACTIVE;
     }
 
     @Override

--- a/app/src/main/java/com/danosoftware/galaxyforce/sprites/game/bases/BasePrimary.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/sprites/game/bases/BasePrimary.java
@@ -571,4 +571,9 @@ public class BasePrimary extends AbstractCollidingSprite implements IBasePrimary
     public boolean isDestroyed() {
         return state == DESTROYED;
     }
+
+    @Override
+    public boolean isActive() {
+        return state == ACTIVE;
+    }
 }

--- a/app/src/main/java/com/danosoftware/galaxyforce/sprites/game/bases/IBase.java
+++ b/app/src/main/java/com/danosoftware/galaxyforce/sprites/game/bases/IBase.java
@@ -17,4 +17,6 @@ public interface IBase extends ICollidingSprite {
     void collectPowerUp(IPowerUp powerUp);
 
     List<ISprite> allSprites();
+
+    boolean isActive();
 }


### PR DESCRIPTION
Fix bug where get ready for next wave message is displayed even if all bases are destroyed at end of wave. Also only advances to next wave once all alien missiles are destroyed. Fixes #98. Fixes #125.